### PR TITLE
Updating to latest llama.cpp 

### DIFF
--- a/cbits/wrapper.c
+++ b/cbits/wrapper.c
@@ -3,12 +3,16 @@
 #include "wrapper.h"
 
 struct llama_model * wrapper_load_model_from_file
-( const char * path_model, struct llama_context_params * params) {
+( const char * path_model, struct llama_model_params * params) {
   return llama_load_model_from_file(path_model, *params);
 }
 
 void wrapper_context_default_params(struct llama_context_params * default_params) {
   *default_params = llama_context_default_params();
+}
+
+void wrapper_model_default_params(struct llama_model_params * default_params) {
+  *default_params = llama_model_default_params();
 }
 
 void wrapper_model_quantize_default_params(struct llama_model_quantize_params * default_params) {

--- a/cbits/wrapper.c
+++ b/cbits/wrapper.c
@@ -7,6 +7,13 @@ struct llama_model * wrapper_load_model_from_file
   return llama_load_model_from_file(path_model, *params);
 }
 
+struct llama_context * wrapper_new_context_with_model(
+            struct llama_model * model,
+            struct llama_context_params * params
+        ) {
+    return llama_new_context_with_model(model, *params);
+}
+
 void wrapper_context_default_params(struct llama_context_params * default_params) {
   *default_params = llama_context_default_params();
 }

--- a/cbits/wrapper.h
+++ b/cbits/wrapper.h
@@ -6,6 +6,12 @@ struct llama_model * wrapper_load_model_from_file(
   struct llama_model_params * params
   );
 
+
+struct llama_context * wrapper_new_context_with_model(
+            struct llama_model * model,
+            struct llama_context_params * params
+        );
+
 void wrapper_context_default_params(struct llama_context_params *);
 
 void wrapper_model_default_params(struct llama_model_params *);

--- a/cbits/wrapper.h
+++ b/cbits/wrapper.h
@@ -3,10 +3,12 @@
 
 struct llama_model * wrapper_load_model_from_file(
   const char * path_model,
-  struct llama_context_params * params
+  struct llama_model_params * params
   );
 
 void wrapper_context_default_params(struct llama_context_params *);
+
+void wrapper_model_default_params(struct llama_model_params *);
 
 void wrapper_model_quantize_default_params(struct llama_model_quantize_params *);
 

--- a/examples/Main.hs
+++ b/examples/Main.hs
@@ -1,7 +1,8 @@
 module Main where
 
 import Prelude hiding (takeWhile)
-
+import System.Exit
+import System.IO
 import Control.Applicative ((<**>))
 import Control.Exception (bracket)
 import Control.Monad.IO.Class (MonadIO, liftIO)
@@ -196,7 +197,9 @@ main = do
       -- I feel like this is not the right way to do this?
       runEffect $
         for (sample >-> takeWhile (/= eos)) $ \id' ->
-          lift . liftIO $ putStr =<< L.tokenToPiece model id'
+          lift . liftIO $ do
+              putStr =<< L.tokenToPiece model id'
+              hFlush stdout
 
 
     sample :: Producer L.Token ContextM ()
@@ -322,15 +325,18 @@ main = do
       putStrLn "\ninit context params"
       L.contextDefaultParams cpp
       L.modelDefaultParams mpp
-      --ctxParams' <- peek cpp
+      ctxParams' <- peek cpp
 
-      --let
-      --  ctxParams = ctxParams'
-      --    -- { L._nCtx = _nCtx params'
-      --    -- , L._nGpuLayers = _nGpuLayers params'
-      --    -- }
+      let
+        ctxParams = ctxParams'
+          { L._nCtx = 2048
+          , L._nBatch = 2048
+          , L._seed = 1234
+          --, L._nThreads = 2
+          --, L._nThreadsBatch = 2
+          }
 
-      --poke cpp ctxParams
+      poke cpp ctxParams
 
       putStrLn "\nloading model"
 

--- a/examples/Main.hs
+++ b/examples/Main.hs
@@ -294,14 +294,6 @@ main = do
             L.sampleRepetitionPenalties
               ctx candidatesPPtr lastNTokensPtr lastNTokensLen (_repeatPenalty params') (1.0) (1.0)
 
-            --L.sampleFrequencyAndPresencePenalties
-            --  ctx
-            --  candidatesPPtr
-            --  lastNTokensPtr
-            --  lastNTokensLen
-            --  (_alphaFrequency params')
-            --  (_alphaPresence params')
-
             -- todo
             -- if (!penalize_nl) {
             --     logits[llama_token_nl()] = nl_logit;

--- a/examples/Main.hs
+++ b/examples/Main.hs
@@ -329,9 +329,9 @@ main = do
 
       let
         ctxParams = ctxParams'
-          { L._nCtx = 2048
-          , L._nBatch = 2048
-          , L._seed = 1234
+          { L._seed = 1234
+          --, L._nCtx = 2048
+          --, L._nBatch = 2048
           --, L._nThreads = 2
           --, L._nThreadsBatch = 2
           }

--- a/llama-cpp-bindings.cabal
+++ b/llama-cpp-bindings.cabal
@@ -64,10 +64,10 @@ executable examples
   main-is:             Main.hs
   default-language:    GHC2021
 
-test-suite llama-cpp-bindings-test
-  import:              shared
-  build-depends:       llama-cpp-bindings
-  hs-source-dirs:      test
-  main-is:             Main.hs
-  default-language:    GHC2021
-  type:                exitcode-stdio-1.0
+-- test-suite llama-cpp-bindings-test
+--   import:              shared
+--   build-depends:       llama-cpp-bindings
+--   hs-source-dirs:      test
+--   main-is:             Main.hs
+--   default-language:    GHC2021
+--   type:                exitcode-stdio-1.0

--- a/llama-cpp-bindings.cabal
+++ b/llama-cpp-bindings.cabal
@@ -64,10 +64,10 @@ executable examples
   main-is:             Main.hs
   default-language:    GHC2021
 
--- test-suite llama-cpp-bindings-test
---   import:              shared
---   build-depends:       llama-cpp-bindings
---   hs-source-dirs:      test
---   main-is:             Main.hs
---   default-language:    GHC2021
---   type:                exitcode-stdio-1.0
+test-suite llama-cpp-bindings-test
+  import:              shared
+  build-depends:       llama-cpp-bindings
+  hs-source-dirs:      test
+  main-is:             Main.hs
+  default-language:    GHC2021
+  type:                exitcode-stdio-1.0

--- a/src/LLaMACPP.chs
+++ b/src/LLaMACPP.chs
@@ -131,7 +131,7 @@ type ProgressCallback = CFloat -> Ptr () -> IO ()
 --         bool use_mlock;  // force system to keep model in RAM
 --     };
 data ModelParams = ModelParams
-    { _nGpuLayers :: Word32
+    { _nGpuLayers :: Int
     , _mainGpu :: Word32
     , _tensorSplit :: Ptr CFloat
     , _progressCallback :: FunPtr ProgressCallback
@@ -194,7 +194,7 @@ data ContextParams = ContextParams
   { _seed :: Word32
   , _nCtx :: Int
   , _nBatch :: Int
-  , _nThreads :: Word32
+  , _nThreads :: Int
   , _nThreadsBatch :: Word32
   , _ropeScalingType :: Word8
   , _ropeFreqBase :: CFloat

--- a/src/LLaMACPP.chs
+++ b/src/LLaMACPP.chs
@@ -130,6 +130,7 @@ data ModelParams = ModelParams
     , _mainGpu :: Word32
     }
 -- TODO, implement storable
+{# pointer *model_params as ModelParamsPtr -> ModelParams #}
 
 instance Storable ModelParams where
   sizeOf _ = {# sizeof model_params #}
@@ -204,10 +205,9 @@ data ContextParams = ContextParams
   --, _useMlock :: Bool
   --, _embedding :: Bool
   }
-  -- deriving (Eq, Show) -- needs ProgressCallback instance
+   deriving (Eq, Show) -- needs ProgressCallback instance
 
 {# pointer *context_params as ContextParamsPtr -> ContextParams #}
-{# pointer *model_params as ModelParamsPtr -> ModelParams #}
 
 instance Storable ContextParams where
   sizeOf _ = {# sizeof context_params #}
@@ -428,7 +428,7 @@ freeModel = {# call free_model #}
 
 newContextWithModel :: Model -> ContextParamsPtr -> IO (Context)
 newContextWithModel model ctxParamsPtr =
-  {# call new_context_with_model #} model (castPtr ctxParamsPtr)
+  {# call wrapper_new_context_with_model #} model (castPtr ctxParamsPtr)
 
 
 --


### PR DESCRIPTION
Hi! I updated the bindings to be compatible with the latest head of llama.cpp master - enough to get the Main.hs example working again.

Summary:
* A few functions no longer exist in llama.h: Namely, the *FromModel functions
* The old sampleRepetitionPenalty and sampleFrequencyAndPresencePenalties functions are now replaced with the sole sampleRepetitionPenalties function
* New function in wrapper.c for new_context_with_model
* llama.h's token_to_str has been replaced with token_to_piece. A corresponding wrapper has been added to the Main.hs example

Tested by running the Mixtral MoE model, and it seems to be working properly.
`stack run examples -- -m ../mixtral/mixtral-8x7b-instruct-v0.1.Q2_K.gguf -p "Hello, my name is " -t 12`

I probably should do a version bump of some kind, but I'm not sure - let me know your thoughts. Cheers!